### PR TITLE
fix: category icon crash on title screen and null level error

### DIFF
--- a/src/main/java/cqb13/NumbyHack/NumbyHack.java
+++ b/src/main/java/cqb13/NumbyHack/NumbyHack.java
@@ -16,13 +16,14 @@ import meteordevelopment.meteorclient.systems.hud.HudGroup;
 import meteordevelopment.meteorclient.systems.modules.Category;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.world.item.Items;
 import org.meteordev.starscript.value.Value;
 import org.meteordev.starscript.value.ValueMap;
 import org.slf4j.Logger;
 
 public class NumbyHack extends MeteorAddon {
-    public static final Category CATEGORY = new Category("Numby Hack", Items.TURTLE_HELMET::getDefaultInstance);
+    public static final Category CATEGORY = new Category("Numby Hack", () -> DisplayItemUtils.toStack(Items.TURTLE_HELMET));
     public static final HudGroup HUD_GROUP = new HudGroup("Numby Hack");
     public static final Logger LOGGER = LogUtils.getLogger();
 

--- a/src/main/java/cqb13/NumbyHack/utils/CHMainUtils.java
+++ b/src/main/java/cqb13/NumbyHack/utils/CHMainUtils.java
@@ -66,7 +66,7 @@ public class CHMainUtils {
     public static Entity deadEntity;
 
     public static boolean isDeathPacket(PacketEvent.Receive event) {
-        if (event.packet instanceof ClientboundEntityEventPacket packet) {
+        if (event.packet instanceof ClientboundEntityEventPacket packet && mc.level != null) {
             if (packet.getEventId() == 3) {
                 deadEntity = packet.getEntity(mc.level);
                 return deadEntity instanceof Player;


### PR DESCRIPTION
Fixes two issues:
- Category icon crash on title screen (press right SHIFT -> [crash](https://mclo.gs/BPk5ahB))
- Null level error (force disconnects you from the server, happens only on [the first try](https://mclo.gs/DIo3Ahc))